### PR TITLE
Minor fixes that can be added to PR#3 or merged afterwards

### DIFF
--- a/struts2-archetype-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-plugin/src/main/resources/archetype-resources/pom.xml
@@ -35,6 +35,17 @@
 
     <build>
         <defaultGoal>install</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.6.1</version>
+                <configuration>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
+        </plugins>
     </build>
 
     <properties>

--- a/struts2-archetype-portlet/pom.xml
+++ b/struts2-archetype-portlet/pom.xml
@@ -19,7 +19,7 @@
         <resources>
             <resource>
                 <directory>src/main/resources</directory>
-                <filtering>false</filtering>
+                <filtering>true</filtering>
                 <includes>
                     <include>**/*.*</include>
                 </includes>


### PR DESCRIPTION
Minor fixes that can be added to PR#3 by L. Lenart directly or merged after that PR is merged.
- Set filtering value to true in struts2-archetype-portlet pom.xml (false causes build failure for the project created by the archetype).
**NOTE**: This is already fixed in PR#3 (missed due to local build mistake, so it is redundant here),
- Set the source/target of struts2-archetype-plugin to 1.7 so that the project that archetype creates can compile successfully with JDK 11+.