### PR TITLE
Update for archetype-descriptors / maven-compiler-plugin version consistency

### DIFF
--- a/struts2-archetype-angularjs/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-angularjs/src/main/resources/archetype-resources/pom.xml
@@ -87,7 +87,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <source>1.8</source>

--- a/struts2-archetype-blank/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-blank/src/main/resources/archetype-resources/pom.xml
@@ -74,7 +74,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <source>1.8</source>

--- a/struts2-archetype-blank/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-blank/src/main/resources/archetype-resources/pom.xml
@@ -73,6 +73,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.2</version>
                 <configuration>

--- a/struts2-archetype-convention/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-convention/src/main/resources/archetype-resources/pom.xml
@@ -80,8 +80,9 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <encoding>UTF-8</encoding>
                     <source>1.8</source>

--- a/struts2-archetype-dbportlet/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/struts2-archetype-dbportlet/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor name="struts2-archetype-portlet">
+<archetype-descriptor name="struts2-archetype-dbportlet">
 
     <fileSets>
         <fileSet filtered="true" packaged="true">

--- a/struts2-archetype-dbportlet/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-dbportlet/src/main/resources/archetype-resources/pom.xml
@@ -103,6 +103,7 @@
         <finalName>\${artifactId}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.2</version>
                 <configuration>

--- a/struts2-archetype-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/struts2-archetype-plugin/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor name="struts2-archetype-convention">
+<archetype-descriptor name="struts2-archetype-plugin">
 
     <fileSets>
         <fileSet filtered="true" packaged="true">

--- a/struts2-archetype-plugin/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-plugin/src/main/resources/archetype-resources/pom.xml
@@ -44,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/struts2-archetype-portlet/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-portlet/src/main/resources/archetype-resources/pom.xml
@@ -14,7 +14,7 @@
         <struts2.version>${supported.struts2.version}</struts2.version>
         <portlet.api.version>2.0</portlet.api.version>
         <!-- plugins -->
-        <plugin.compiler.version>3.6.1</plugin.compiler.version>
+        <plugin.compiler.version>3.6.2</plugin.compiler.version>
         <plugin.war.version>2.3</plugin.war.version>
         <plugin.pluto.version>2.0.3</plugin.pluto.version>
     </properties>

--- a/struts2-archetype-starter/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/struts2-archetype-starter/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<archetype-descriptor name="struts2-archetype-convention">
+<archetype-descriptor name="struts2-archetype-starter">
 
     <fileSets>
         <fileSet filtered="true" packaged="true">

--- a/struts2-archetype-starter/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-starter/src/main/resources/archetype-resources/pom.xml
@@ -94,7 +94,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.1</version>
+                <version>3.6.2</version>
                 <configuration>
                     <source>1.8</source>
                     <target>1.8</target>

--- a/struts2-archetype-starter/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-starter/src/main/resources/archetype-resources/pom.xml
@@ -93,6 +93,7 @@
         <finalName>${artifactId}</finalName>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.2</version>
                 <configuration>


### PR DESCRIPTION
Minor changes:
- Make all archetype-descriptor "name" attributes match the archetype they belong to.
- Make all maven-compiler-plugin versions 3.6.2.