### PR TITLE
Minor archetype fixes for generated project unit tests

### DIFF
--- a/struts2-archetype-angularjs/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-angularjs/src/main/resources/archetype-resources/pom.xml
@@ -67,6 +67,14 @@
         </dependency>
 
         <dependency>
+            <!-- Needed for tests to run under JDK11 (works without it in JDK8).  Why?  That is still unclear. -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/struts2-archetype-blank/src/main/resources/archetype-resources/src/test/java/example/LoginTest.java
+++ b/struts2-archetype-blank/src/main/resources/archetype-resources/src/test/java/example/LoginTest.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class LoginTest extends ConfigTest {
 
     public void testLoginConfig() {
-        ActionConfig config = assertClass("/example", "Login_input", "${package}.Login");
+        ActionConfig config = assertClass("/example", "Login_input", "${package}.example.Login");
         assertResult(config, ActionSupport.SUCCESS, "Menu");
         assertResult(config, ActionSupport.INPUT, "/WEB-INF/example/Login.jsp");
     }

--- a/struts2-archetype-convention/src/main/resources/archetype-resources/pom.xml
+++ b/struts2-archetype-convention/src/main/resources/archetype-resources/pom.xml
@@ -61,6 +61,14 @@
         </dependency>
 
         <dependency>
+            <!-- Needed for tests to run under JDK11 (works without it in JDK8).  Why?  That is still unclear. -->
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>1.20</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
             <version>3.1.0</version>

--- a/struts2-archetype-convention/src/main/resources/archetype-resources/src/main/java/actions/HelloAction.java
+++ b/struts2-archetype-convention/src/main/resources/archetype-resources/src/main/java/actions/HelloAction.java
@@ -13,7 +13,7 @@ public class HelloAction extends ActionSupport {
     }
 
     /**
-     * Provide default valuie for Message property.
+     * Provide default value for Message property.
      */
     public static final String MESSAGE = "hello.message";
 

--- a/struts2-archetype-convention/src/main/resources/archetype-resources/src/test/java/actions/HelloActionTest.java
+++ b/struts2-archetype-convention/src/main/resources/archetype-resources/src/test/java/actions/HelloActionTest.java
@@ -7,7 +7,7 @@ import com.opensymphony.xwork2.ActionSupport;
 
 public class HelloActionTest extends StrutsTestCase {
 
-    public void testHelloAction() {
+    public void testHelloAction() throws Exception {
         HelloAction hello = new HelloAction();
         ActionContext.getContext().getContainer().inject(hello);
         String result = hello.execute();


### PR DESCRIPTION
Minor archetype fixes:
- Allow the unit tests for projects built from the Angular and Convention archetypes to run under JDK 11 (issue not seen with JDK8).
- Fix broken unit test for projects built from Blank archetype.
- Fix broken unit test for projects built from Convention archetype.
- Fix comment typo in HelloAction for the Convention archetype.